### PR TITLE
feat: use latest boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 terraform/.terraform.lock.hcl
 terraform/.terraform
-terraform/terraform.state*
+terraform/terraform.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+terraform/.terraform.lock.hcl
+terraform/.terraform
+terraform/terraform.state*

--- a/compose/controller.hcl
+++ b/compose/controller.hcl
@@ -10,15 +10,15 @@ controller {
 }
 
 listener "tcp" {
-  address = "boundary"
+  address = "0.0.0.0:9200"
   purpose = "api"
   tls_disable = true
   cors_enabled = true
-	cors_allowed_origins = ["*"]
+  cors_allowed_origins = ["*"]
 }
 
 listener "tcp" {
-  address = "boundary"
+  address = "boundary:9201"
   purpose = "cluster"
   tls_disable = true
 }

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -105,8 +105,7 @@ services:
       - worker2
 
   mysql:
-    # image: mysql does not have an M1 compatible version
-    image: mysql:oracle
+    image: mariadb
     environment:
       - 'MYSQL_ROOT_PASSWORD=my-secret-pw'
     networks:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 3s
       timeout: 10s
-      retries: 5
+      retries: 10
 
   db-init:
     image: hashicorp/boundary:0.7.5
@@ -33,7 +33,8 @@ services:
 
   controller:
     image: hashicorp/boundary:0.7.5
-    # command: ["server", "-config", "/boundary/controller.hcl"]
+    # I had to `docker restart boundary_controller_1` a couple times when
+    # running on an Ubuntu host.
     entrypoint: sh -c "sleep 3 && exec boundary server -config /boundary/controller.hcl -log-level debug"
     volumes:
       - "${PWD}/:/boundary/"
@@ -104,7 +105,8 @@ services:
       - worker2
 
   mysql:
-    image: mysql
+    # image: mysql does not have an M1 compatible version
+    image: mysql:oracle
     environment:
       - 'MYSQL_ROOT_PASSWORD=my-secret-pw'
     networks:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.6.2
+    image: hashicorp/boundary:0.7.5
     command: ["database", "init", "-config", "/boundary/controller.hcl"]
     volumes:
       - "${PWD}/:/boundary/"
@@ -32,9 +32,9 @@ services:
         condition: service_healthy
 
   controller:
-    image: hashicorp/boundary:0.6.2
+    image: hashicorp/boundary:0.7.5
     # command: ["server", "-config", "/boundary/controller.hcl"]
-    entrypoint: sh -c "sleep 3 && exec boundary server -config /boundary/controller.hcl"
+    entrypoint: sh -c "sleep 3 && exec boundary server -config /boundary/controller.hcl -log-level debug"
     volumes:
       - "${PWD}/:/boundary/"
     hostname: boundary
@@ -51,8 +51,8 @@ services:
       - worker2
 
   worker1:
-    image: hashicorp/boundary:0.6.2
-    command: ["server", "-config", "/boundary/worker1.hcl"]
+    image: hashicorp/boundary:0.7.5
+    command: ["server", "-config", "/boundary/worker1.hcl", "-log-level", "debug"]
     volumes:
       - "${PWD}/:/boundary/"
     hostname: worker1
@@ -67,8 +67,8 @@ services:
       - worker1
 
   worker2:
-    image: hashicorp/boundary:0.6.2
-    command: ["server", "-config", "/boundary/worker2.hcl"]
+    image: hashicorp/boundary:0.7.5
+    command: ["server", "-config", "/boundary/worker2.hcl", "-log-level", "debug"]
     volumes:
       - "${PWD}/:/boundary/"
     hostname: worker2
@@ -86,8 +86,6 @@ services:
 
   postgres:
     image: postgres
-    networks:
-      - worker1
     environment:
       - POSTGRES_DB=test1
       - POSTGRES_USER=postgres
@@ -97,6 +95,8 @@ services:
       interval: 3s
       timeout: 10s
       retries: 5
+    networks:
+      - worker1
 
   redis:
     image: redis

--- a/compose/worker1.hcl
+++ b/compose/worker1.hcl
@@ -17,7 +17,6 @@ worker {
   tags {
     region    = ["us-east-1"],
     type      = ["prod"]
-    // type      = ["prod", "databases"]
     // type      = ["prod", "databases", "postgres", "mysql"]
   }
 }

--- a/compose/worker1.hcl
+++ b/compose/worker1.hcl
@@ -13,11 +13,12 @@ worker {
   description = "A worker for a docker demo"
   address     = "worker1"
   public_addr = "localhost:9202"
-  controllers = ["boundary"]
+  controllers = ["boundary:9201"]
   tags {
     region    = ["us-east-1"],
     type      = ["prod"]
-    // type      = ["prod", "database", "postgres", "mysql"]
+    // type      = ["prod", "databases"]
+    // type      = ["prod", "databases", "postgres", "mysql"]
   }
 }
 

--- a/compose/worker1.hcl
+++ b/compose/worker1.hcl
@@ -17,7 +17,7 @@ worker {
   tags {
     region    = ["us-east-1"],
     type      = ["prod"]
-    // type      = ["prod", "databases", "postgres", "mysql"]
+    // type      = ["prod", "database", "postgres", "mysql"]
   }
 }
 

--- a/compose/worker2.hcl
+++ b/compose/worker2.hcl
@@ -13,11 +13,11 @@ worker {
   description = "A worker for a docker demo"
   address     = "worker2"
   public_addr = "localhost:9203"
-  controllers = ["boundary"]
+  controllers = ["boundary:9201"]
   tags {
     region    = ["us-west-1"],
     type      = ["dev"]
-    // type      = ["dev", "database", "redis"]
+    // type      = ["dev", "databases", "redis"]
   }
 }
 

--- a/compose/worker2.hcl
+++ b/compose/worker2.hcl
@@ -17,7 +17,7 @@ worker {
   tags {
     region    = ["us-west-1"],
     type      = ["dev"]
-    // type      = ["dev", "databases", "redis"]
+    // type      = ["dev", "database", "redis"]
   }
 }
 

--- a/run
+++ b/run
@@ -1,44 +1,40 @@
 #!/bin/bash
 
 function cleanup() {
-  pushd compose
-  docker compose -p boundary rm -fs 
-  popd
-  pushd terraform/
+  pushd compose || exit 1
+  docker compose -p boundary rm -fsv
+  popd || exit 1
+  pushd terraform || exit 1
   rm terraform.tfstate*
-  popd
+  popd || exit 1
   exit 0
 }
-trap cleanup SIGKILL SIGINT
+trap cleanup SIGINT
 
 function init_compose() {
-  pushd compose/
+  pushd compose || exit 1
   docker compose --project-name boundary up -d
-  popd
+  popd || exit 1
 }
 
 function init_terraform() {
-  pushd terraform
+  pushd terraform || exit 1
   terraform init
   terraform apply -auto-approve
-  popd
+  popd || exit 1
 }
 
 # Test with login to Boundary after provisioning
 function login() {
-  boundary authenticate password -login-name jeff -password foofoofoo -auth-method-id $(primary_org_ampw)
+  boundary authenticate password -login-name user1 -password password -auth-method-id "$(primary_org_ampw)"
 }
 
 function primary_org_id() {
-  strip $(boundary scopes list -format json | jq  -c '.[] | select(.name | contains("primary")) | .["id"]')
+  boundary scopes list -format json | jq -r -c '.items[] | select(.name | contains("primary")) | .["id"]'
 }
 
 function primary_org_ampw() {
-  strip $(boundary auth-methods list -scope-id $(primary_org_id) -format json | jq -c '.[]["id"]') 
-}
-
-function strip() {
-  echo "$1" | tr -d '"'
+  boundary auth-methods list -scope-id "$(primary_org_id)" -format json | jq -r -c '.items[]["id"]'
 }
 
 for arg in "$@"

--- a/run
+++ b/run
@@ -2,7 +2,7 @@
 
 function cleanup() {
   pushd compose || exit 1
-  docker compose -p boundary rm -fsv
+  docker-compose -p boundary rm -fsv
   popd || exit 1
   pushd terraform || exit 1
   rm terraform.tfstate*
@@ -13,7 +13,7 @@ trap cleanup SIGINT
 
 function init_compose() {
   pushd compose || exit 1
-  docker compose --project-name boundary up -d
+  docker-compose --project-name boundary up -d
   popd || exit 1
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -126,7 +126,7 @@ resource "boundary_host" "localhost" {
 }
 
 # Target hosts available on localhost: ssh and postgres
-# Postgres is exposed to localhost for debugging of the 
+# Postgres is exposed to localhost for debugging of the
 # Boundary DB from the CLI. Assumes SSHD is running on
 # localhost.
 resource "boundary_host_set" "local" {
@@ -255,7 +255,7 @@ resource "boundary_target" "mysql" {
   host_set_ids = [
     boundary_host_set.mysql.id
   ]
-  worker_filter                = "\"/name\" == \"bad filter\""
+  worker_filter = "\"/name\" == \"bad filter\""
   // worker_filter             = "\"/name\" == \"worker1\" or (\"prod\" in \"/tags/type\" and \"database\" in \"/tags/type\")"
   // worker_filter_unformatted = "/name" == "worker1" or ("prod" in "/tags/type" and "database" in "/tags/type")" # Unformatted filter, don't uncomment
 }


### PR DESCRIPTION
This might not be relevant or necessary.  I haven't spent too much time here but I've had some issues getting this to run consistently and predictably.  I don't think it's too significant except for the `mysql:oracle` change, but it's worth noting that I was testing on an Apple M1.

Otherwise, this change includes:
* bump the boundary container image being used from `0.6.2` to `0.7.5`
* when running through https://learn.hashicorp.com/tutorials/boundary/target-aware-workers, if I was not binding `boundary`'s tcp listener to `0.0.0.0:9200`, I could not `terraform apply` from my local machine.
* running this locally on a Mac M1 breaks at `image: mysql` as there is no relevant version.  This 'could' be fixed by tagging to `image: mysql:oracle`.
* I don't think I 'had' to be explicit about the port for the `controller` in the worker hcl's, but I was during testing.
* I found `-log-level debug` to be useful during troubleshooting, but I could see this being not desirable.

I tried running again on an Ubuntu x86_64 machine but had to install `docker-compose` by hand because `docker` on Ubuntu does not ship with `docker compose` like Docker Desktop.  I modified `docker compose` to include the hyphen.  I ran into other issues on that machine with regards to startup timing, acquiring a lock on postgres, and the controller crashing.